### PR TITLE
Store the wpm and farnsworth settings to local storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "podcast": "^1.3.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "rss-parser": "^3.9.0"
+    "rss-parser": "^3.9.0",
+    "use-persisted-state": "^0.3.0"
   },
   "devDependencies": {
     "@types/node": "^14.11.1",

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,6 +4,7 @@ import { useState, useRef } from 'react'
 import MorseCWWave from 'morse-pro/lib/morse-pro-cw-wave'
 import getDataURI from 'morse-pro/lib/morse-pro-util-datauri';
 import * as RiffWave from 'morse-pro/lib/morse-pro-util-riffwave';
+import createPersistedState from 'use-persisted-state';
 
 const readFileAsync = promisify(readFile);
 
@@ -22,10 +23,13 @@ export async function getStaticProps(context) {
   }
 }
 
+const wpmState = createPersistedState('wpm');
+const fwpmState = createPersistedState('fwpm');
+
 export default function Index({headlines, createdOn}) {
   const [currentTrackIdx, setCurrentTrackIdx] = useState(-1)
-  const [wpm, setWpm] = useState(20)
-  const [fwpm, setFwpm] = useState(20)
+  const [wpm, setWpm] = wpmState(20)
+  const [fwpm, setFwpm] = fwpmState(20)
   const audioRef = useRef()
 
   function validateSpeed() {


### PR DESCRIPTION
I don't know much about modern Javascript, so I don't know what I'm doing here. I'd love to have the wpm and Farnsworth speed settings saved across page reloads, and this seems to do the trick for me.